### PR TITLE
feat: Permite rodar os testes em navegadores virtualizados

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,15 @@
 - Clone the repo
 - run: pipenv install
 - run: pipenv run python -m pytest -n <'threads'>
+
+If using Windows: Install WSL
+
+- Install docker
+- pull selenium hub image
+- pull selenium node <'browser'> image
+
+Start WSL
+Open docker desktop
+
+- run: docker-compose up -d
+- run: docker ps -a

--- a/config.json
+++ b/config.json
@@ -1,5 +1,7 @@
 {
     "browser": "Chrome",
     "type": "local",
-    "implicit_wait": 10
+    "implicit_wait": 10,
+    "url_remote": "http://localhost:4444/wd/hub",
+    "environment": "https://crmrbacademy.apprubeus.com.br"
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3"
+
+services:
+  selenium-hub:
+    image: selenium/hub
+    container_name: selenium-hub
+    ports:
+      - "4444:4444"
+    environment:
+      GRID_MAX_SESSION: 8
+      GRID_BROWSER_TIMEOUT: 300
+      GRID_TIMEOUT: 300
+
+  chrome:
+    image: selenium/node-chrome:129.0
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - NODE_MAX_SESSION=2
+      - NODE_MAX_INSTANCES=2
+    # volumes:
+    #   - /dev/shm:/dev/shm
+
+  firefox:
+    image: selenium/node-firefox
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - NODE_MAX_SESSION=2
+      - NODE_MAX_INSTANCES=2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,8 @@ This module contains shared fixtures
 
 import json
 import pytest
-import selenium.webdriver
+import selenium.webdriver as webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
 
@@ -20,6 +21,10 @@ def config(scope='session'):
     assert config['type'] in ['local', 'remote']
     assert isinstance(config['implicit_wait'], int)
     assert config['implicit_wait'] > 0
+    assert isinstance(config['url_remote'], str)
+    assert len(config['url_remote']) > 0
+    assert isinstance(config['environment'], str)
+    assert len(config['environment']) > 0
 
     # Return a dictionary of configs
     return config
@@ -30,16 +35,39 @@ def config(scope='session'):
 def browser(config):
 
     #Inicializa uma instancia do WebDriver
-    if config['browser'] == 'Firefox':
-        b.selenium.webdriver.Firefox()
-    elif config['browser'] == 'Chrome':
-        b = selenium.webdriver.Chrome()
-    elif config['browser'] == 'Headless Chrome':
-        opts = selenium.webdriver.ChromeOptions()
-        opts.add_argument('headless')
-        b = selenium.webdriver.Chrome(options=opts)
+    if config['type'] == 'local':
+
+        if config['browser'] == 'Firefox':
+            opts = webdriver.FirefoxOptions()
+            opts.add_argument('--window-size=1366,768')
+            b.webdriver.Firefox(options=opts)
+        elif config['browser'] == 'Chrome':
+            opts = webdriver.ChromeOptions()
+            opts.add_argument('--window-size=1366,768')
+            b = webdriver.Chrome(options=opts)
+        elif config['browser'] == 'Headless Chrome':
+            opts = webdriver.ChromeOptions()
+            opts.add_argument('headless')
+            b = webdriver.Chrome(options=opts)
+        else:
+            raise Exception(f'Browser "{config["browser"]}" is not supported')
+    
+    elif config['type'] == 'remote':
+        
+        if config['browser'] == 'Firefox':
+            opts = webdriver.FirefoxOptions()
+        elif config['browser'] == 'Chrome':
+            opts = webdriver.ChromeOptions()
+
+        opts.add_argument('--no-sandbox')
+
+        b = webdriver.Remote(
+            command_executor = config['url_remote'],
+            options=opts
+        )
+
     else:
-        raise Exception(f'Browser "{config["Browser"]}" is not supported')
+        raise Exception(f'Type "{config["type"]}" is not supported')
 
     #Faz o navegador esperar até 10s pro elemento aparecer
     b.implicitly_wait(config['implicit_wait'])


### PR DESCRIPTION
Com novos campos no arquivo de configuração, agora é possível rodar os testes no ambiente local, porém acessando navegadores virtualizados pelo Docker.